### PR TITLE
Handle sourcemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log*
 node_modules
 *.tgz
 dist
+src/__tests__/__out

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "rollup": "^1.25.1",
     "tslib": "^1.10.0",
     "typescript": "^3.6.4"
+  },
+  "dependencies": {
+    "magic-string": "^0.25.7"
   }
 }

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,7 +1,13 @@
 import path from 'path';
-import { rollup } from 'rollup';
+import { rollup, RollupWarning } from 'rollup';
 
 import { preserveShebangs } from '..';
+
+type WarningParam = string | RollupWarning // Rollup@1
+// type WarningParam = RollupWarning // Rollup@2
+
+const getWarningCode = (warning: WarningParam) =>
+  typeof warning === 'string' ? warning : warning.code;
 
 it('preserves shebang in output file', async () => {
   const bundle = await rollup({
@@ -10,6 +16,26 @@ it('preserves shebang in output file', async () => {
   });
 
   const output = await bundle.generate({ format: 'cjs' });
-
   expect(output.output[0].code.startsWith('#!/usr/bin/env node')).toBe(true);
+});
+
+it('supports sourcemaps', async () => {
+  let sourcemapOk = true;
+
+  const bundle = await rollup({
+    input: path.join(__dirname, './fixtures/file.js'),
+    plugins: [preserveShebangs()],
+    onwarn: (warning, deafultHandler) => {
+      sourcemapOk = sourcemapOk && getWarningCode(warning) !== 'SOURCEMAP_BROKEN';
+      deafultHandler(warning);
+    },
+  });
+
+  const output = await bundle.write({
+    format: 'cjs',
+    sourcemap: true,
+    dir: path.join(__dirname, './__out'),
+  });
+  expect(output.output[0].code.startsWith('#!/usr/bin/env node')).toBe(true);
+  expect(sourcemapOk).toBe(true);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Plugin } from 'rollup';
+import MagicString from 'magic-string';
 
 const SHEBANG_RX = /^#!.*/;
 
@@ -21,12 +22,19 @@ export const preserveShebangs = () => {
         map: null,
       };
     },
-    renderChunk(code, chunk) {
+    renderChunk(code, chunk, { sourcemap }) {
       if (chunk.facadeModuleId && shebangs[chunk.facadeModuleId]) {
-        code = [shebangs[chunk.facadeModuleId], code].join('\n');
+        const str = new MagicString(code);
+        str.prepend(shebangs[chunk.facadeModuleId] + '\n');
+        return {
+          code: str.toString(),
+          map: sourcemap ? str.generateMap({ hires: true }) : null,
+        };
       }
-
-      return { code };
+      return {
+        code,
+        map: null,
+      };
     },
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,6 +2757,13 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -3716,6 +3723,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Hi, I noticed that using this plugin with the `sourcemap: true` option triggers a build warning, and it felt like creating a fix was the responsible thing to do.